### PR TITLE
3 css reset

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,6 +10,8 @@ This repository uses a Test Driven Development approach.
 3. Add .env file and update the missing credentials.
    The following will be needed:
 
+   - VITE_MAPBOX_TOKEN
+
 4. npm run dev
 
 ---

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -69,7 +69,14 @@ Mapbox
   > "state" & filtering function
   > < How to request data on-demand & at a set interval? Or more strictly like weather.com
 
-- full CSS reset
+[x] initialize project with Vite, React, SWC
+[x] prettier
+[x] jest setup
+[x] typescript
+[x] tailwind, shadcn
+[x] initialized heatmap component
+[x] CSS reset
+
 - style variables
 - Setting up SCSS, show Block-Element-Modifier styling syntax
 - CSS for JS developers research on styling / design system

--- a/firecast-frontend/src/App.css
+++ b/firecast-frontend/src/App.css
@@ -1,42 +1,41 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+/*
+  Josh Comeau's Custom CSS Reset
+  https://www.joshwcomeau.com/css/custom-css-reset/
+*/
+
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+* {
+  margin: 0;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+body {
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+img, picture, video, canvas, svg {
+  display: block;
+  max-width: 100%;
 }
 
-.card {
-  padding: 2em;
+input, button, textarea, select {
+  font: inherit;
 }
 
-.read-the-docs {
-  color: #888;
+p, h1, h2, h3, h4, h5, h6 {
+  overflow-wrap: break-word;
+}
+
+p {
+  text-wrap: pretty;
+}
+h1, h2, h3, h4, h5, h6 {
+  text-wrap: balance;
+}
+
+#root, #__next {
+  isolation: isolate;
 }

--- a/firecast-frontend/vite.config.ts
+++ b/firecast-frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 import path from "path"
-import react from "@vitejs/plugin-react"
+import react from "@vitejs/plugin-react-swc"
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,7 +9,7 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     }
-  }
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
This PR includes fixes for the vite.config.ts file:
- separating comma between test and resolve
- importing vite-react-swc

Also, the ReadMe.md includes instructions to define a .env file for the project with the necessary credential for using Mapbox. Otherwise the app crashes.

Finally, a CSS reset was applied based on the styles provided by Josh Comeau.